### PR TITLE
Within a channel timeout, check for ban reason existing as a key

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -303,7 +303,7 @@ def twitch_clearchat(data, modifier, modifier_data, string):
         rul = weechat.color("-underline")
         if user:
             if 'ban-duration' in tags:
-                if tags['ban-reason']:
+                if 'ban-reason' in tags and tags['ban-reason']:
                     bn=tags['ban-reason'].replace('\s',' ')
                     weechat.prnt(buffer,"%s--%s %s has been timed out for %s seconds %sReason%s: %s" %
                         (pcolor, ccolor, user, tags['ban-duration'], ul, rul, bn))


### PR DESCRIPTION
key before using its value. There's an explicit check for this outside of a timeout, but within the timeout it throws a KeyError if someone is timed out without a reason.