### PR TITLE
Fix invalid escape sequences, noisy since py3.12, deprecated since py3.6

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -87,6 +87,7 @@ from datetime import datetime, timedelta
 import time
 import string
 import ast
+import re
 
 curlopt = {
     "httpheader": "\n".join([
@@ -351,7 +352,7 @@ def twitch_clearchat(data, modifier, modifier_data, string):
         if user:
             if 'ban-duration' in tags:
                 if 'ban-reason' in tags and tags['ban-reason']:
-                    bn=tags['ban-reason'].replace('\s',' ')
+                    bn=re.sub(r'\s',' ', tags['ban-reason'])
                     weechat.prnt(buffer,"%s--%s %s has been timed out for %s seconds %sReason%s: %s" %
                         (pcolor, ccolor, user, tags['ban-duration'], ul, rul, bn))
                 else:
@@ -359,7 +360,7 @@ def twitch_clearchat(data, modifier, modifier_data, string):
                         (pcolor, ccolor, user, tags['ban-duration']))
             elif 'ban-reason' in tags:
                 if tags['ban-reason']:
-                    bn=tags['ban-reason'].replace('\s',' ')
+                    bn=re.sub(r'\s', ' ', tags['ban-reason'])
                     weechat.prnt(buffer,"%s--%s %s has been banned %sReason%s: %s" %
                         (pcolor, ccolor, user, ul, rul,bn))
                 else:
@@ -456,7 +457,7 @@ def twitch_usernotice(data, modifier, server, string):
         "irc", "%s.%s" % (server, mp['channel']))
     if mp['tags']:
         tags = dict([s.split('=',1) for s in mp['tags'].split(';')])
-        msg = tags['system-msg'].replace('\s',' ')
+        msg = re.sub(r'\\s', ' ', tags['system-msg'])
         if mp['text']:
             msg += ' [Comment] '+mp['text']
         weechat.prnt(buffer, '%s--%s %s' % (pcolor, ccolor, msg))


### PR DESCRIPTION
Fixes invalid escape sequences, which were deprecated since py3.6 and started raising SyntaxWarnings since py3.12, example follows.

```
python: stdout/stderr (?): /home/user/.weechat/python/twitch.py:354: SyntaxWarning: invalid escape sequence '\s'
python: stdout/stderr (?):   bn=tags['ban-reason'].replace('\s',' ')
python: stdout/stderr (?): /home/user/.weechat/python/twitch.py:362: SyntaxWarning: invalid escape sequence '\s'
python: stdout/stderr (?):   bn=tags['ban-reason'].replace('\s',' ')
python: stdout/stderr (?): /home/user/.weechat/python/twitch.py:459: SyntaxWarning: invalid escape sequence '\s'
python: stdout/stderr (?):   msg = tags['system-msg'].replace('\s',' ')
```

Upstream references:
- https://github.com/python/cpython/issues/98401
- https://docs.python.org/3/whatsnew/3.12.html#other-language-changes